### PR TITLE
Fix alt text in mission page

### DIFF
--- a/mission.html
+++ b/mission.html
@@ -76,7 +76,7 @@
           </div>
         </div>
         <div class="principle-item">
-          <img src="assets/icons/ready.png" alt="No Dogma" class="principle-icon" />
+          <img src="assets/icons/ready.png" alt="Inner Readiness" class="principle-icon" />
           <div>
             <h4>Inner Readiness</h4>
             <p>No substitute for inner work. We prepare mind and spirit before the journey.</p>


### PR DESCRIPTION
## Summary
- correct the alt text for the inner readiness icon

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest` *(fails: command not found)*