### PR TITLE
Center plant images on small screens

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -421,6 +421,10 @@ body {
   .plant-section {
     padding: 15px;
   }
+  .plant-img {
+    margin-left: auto;
+    margin-right: auto;
+  }
   .method-table th,
   .method-table td {
     font-size: 0.95em;


### PR DESCRIPTION
## Summary
- tweak Methods page CSS so `.plant-img` is centered when the screen is narrow

## Testing
- `npm test` *(fails: could not find package.json)*