### PR TITLE
Make intensity column compact

### DIFF
--- a/methods.html
+++ b/methods.html
@@ -124,7 +124,7 @@
         <thead>
           <tr>
             <th>Plant</th>
-            <th>Intensity</th>
+            <th class="intensity-col">Intensity</th>
             <th>Duration</th>
             <th>Best For</th>
           </tr>
@@ -132,25 +132,25 @@
         <tbody>
           <tr>
             <td>Morning Glory</td>
-            <td><span class="intensity-icon intensity-moderate"></span>Moderate</td>
+            <td class="intensity-col"><span class="intensity-icon intensity-moderate"></span></td>
             <td>6–8 hrs</td>
             <td>Symbolic insight, emotional inquiry</td>
           </tr>
           <tr>
             <td>Psilocybin</td>
-            <td><span class="intensity-icon intensity-medium"></span>Medium</td>
+            <td class="intensity-col"><span class="intensity-icon intensity-medium"></span></td>
             <td>4–6 hrs</td>
             <td>Trauma work, spiritual exploration</td>
           </tr>
           <tr>
             <td>San Pedro</td>
-            <td><span class="intensity-icon intensity-high"></span>High</td>
+            <td class="intensity-col"><span class="intensity-icon intensity-high"></span></td>
             <td>10–14 hrs</td>
             <td>Heart opening, nature connection</td>
           </tr>
           <tr>
             <td>Marijuana</td>
-            <td><span class="intensity-icon intensity-low"></span>Low</td>
+            <td class="intensity-col"><span class="intensity-icon intensity-low"></span></td>
             <td>2–4 hrs</td>
             <td>Grounding, priming, somatic release</td>
           </tr>

--- a/styles.css
+++ b/styles.css
@@ -402,6 +402,16 @@ body {
   font-size: 1.05em;
   word-break: break-word;
 }
+.method-table .intensity-col {
+  width: 40px;
+  text-align: center;
+}
+.method-table .intensity-col .intensity-icon {
+  margin-right: 0;
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}
 .method-table th {
   background: var(--parchment-bg-light);
   color: var(--text-secondary);


### PR DESCRIPTION
## Summary
- reduce the width of the intensity column in the method table
- show only the icon for intensity instead of text

## Testing
- `git status --short`