### PR TITLE
Close hamburger menu when clicking outside

### DIFF
--- a/script.js
+++ b/script.js
@@ -5,6 +5,17 @@ document.addEventListener('DOMContentLoaded', function() {
     hamburger.addEventListener('click', function() {
       nav.classList.toggle('open');
     });
+
+    // Close the mobile menu when clicking outside of it
+    document.addEventListener('click', function(event) {
+      if (
+        nav.classList.contains('open') &&
+        !nav.contains(event.target) &&
+        !hamburger.contains(event.target)
+      ) {
+        nav.classList.remove('open');
+      }
+    });
   }
 
   // Highlight the active page in the navigation


### PR DESCRIPTION
## Summary
- close the mobile navigation when clicking outside the hamburger menu

## Testing
- `pre-commit` *(fails: command not found)*