### PR TITLE
Fix mobile nav menu gap

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -135,7 +135,7 @@ body {
 
   .nav-links {
     position: absolute;
-    top: 60px;
+    top: 100%;
     left: 0;
     right: 0;
     background: rgba(244, 236, 216, 0.95);


### PR DESCRIPTION
## Summary
- make mobile navigation flush with banner by using `top: 100%`

## Testing
- `git status --short`