### PR TITLE
Add FastAPI notes and link costs page to location

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,29 @@ Each page includes a shared navigation banner at the top so visitors can easily 
 ## Viewing Locally
 
 Because the site is purely static, you can open any of the HTML files directly in your web browser. Simply double-click a page or use `File -> Open` in your browser to view it.
+
+## FastAPI Server Stack
+
+If you'd prefer to serve the files through a small Python backend, the site works well with a FastAPI stack.
+
+### Install dependencies
+
+```bash
+pip install fastapi uvicorn
+```
+
+### Example server
+
+```python
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+
+app = FastAPI()
+app.mount("/", StaticFiles(directory=".", html=True), name="static")
+```
+
+### Run the server
+
+```bash
+uvicorn main:app --reload
+```

--- a/costs.html
+++ b/costs.html
@@ -54,6 +54,7 @@
       <h3>Cancellation Policy</h3>
       <p>Cancellations more than two weeks before your session are fully refundable. After that we retain a 30% deposit to cover preparation costs.</p>
     </section>
+    <p class="costs-location-link">For details on where sessions are held, visit our <a href="location.html">location page</a>.</p>
 
     <footer class="page-footer">
       <a href="contact.html" class="cta-button">Contact Us</a>


### PR DESCRIPTION
## Summary
- reference the location page from the costs page
- document how to use a FastAPI stack in the README

## Testing
- `pytest -q`