### PR TITLE
Add group session calendar

### DIFF
--- a/costs.html
+++ b/costs.html
@@ -55,6 +55,11 @@
       <h3>Cancellation Policy</h3>
       <p>Cancellations more than two weeks before your session are fully refundable. After that we retain a 30% deposit to cover preparation costs.</p>
     </section>
+
+    <section class="costs-section">
+      <h3>Group Session Calendar</h3>
+      <div id="session-calendar"></div>
+    </section>
     <p class="costs-location-link">For details on where sessions are held, visit our <a href="location.html">location page</a>.</p>
 
     <footer class="page-footer">

--- a/script.js
+++ b/script.js
@@ -25,4 +25,62 @@ document.addEventListener('DOMContentLoaded', function() {
       link.classList.add('active');
     }
   });
+
+  // Group session calendar on the costs page
+  function renderCalendar(containerId, year, month, sessionDays) {
+    const container = document.getElementById(containerId);
+    if (!container) return;
+
+    const monthNames = [
+      'January','February','March','April','May','June',
+      'July','August','September','October','November','December'
+    ];
+
+    const calendar = document.createElement('table');
+    calendar.className = 'calendar';
+
+    const caption = document.createElement('caption');
+    caption.textContent = `${monthNames[month]} ${year}`;
+    calendar.appendChild(caption);
+
+    const headerRow = document.createElement('tr');
+    const days = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];
+    days.forEach(d => {
+      const th = document.createElement('th');
+      th.textContent = d;
+      headerRow.appendChild(th);
+    });
+    calendar.appendChild(headerRow);
+
+    let date = new Date(year, month, 1);
+    let row = document.createElement('tr');
+    for (let i = 0; i < date.getDay(); i++) {
+      row.appendChild(document.createElement('td'));
+    }
+
+    const monthLength = new Date(year, month + 1, 0).getDate();
+    for (let day = 1; day <= monthLength; day++) {
+      if (row.children.length === 7) {
+        calendar.appendChild(row);
+        row = document.createElement('tr');
+      }
+      const cell = document.createElement('td');
+      cell.textContent = day;
+      if (sessionDays.includes(day)) {
+        cell.classList.add('session-day');
+      }
+      row.appendChild(cell);
+    }
+
+    while (row.children.length < 7) {
+      row.appendChild(document.createElement('td'));
+    }
+    calendar.appendChild(row);
+    container.appendChild(calendar);
+  }
+
+  if (document.getElementById('session-calendar')) {
+    // Example group session dates for July 2024
+    renderCalendar('session-calendar', 2024, 6, [6, 20]);
+  }
 });

--- a/styles.css
+++ b/styles.css
@@ -866,6 +866,30 @@ body {
   font-size: 1.1em;
 }
 
+.calendar {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.5em 0;
+}
+
+.calendar th,
+.calendar td {
+  border: 1px solid #ccc;
+  padding: 6px;
+  text-align: center;
+}
+
+.calendar th {
+  background: var(--parchment-bg-light);
+  color: var(--text-secondary);
+}
+
+.calendar .session-day {
+  background: var(--accent);
+  color: #fff;
+  font-weight: bold;
+}
+
 .page-footer {
   text-align: center;
   margin-top: 3em;


### PR DESCRIPTION
## Summary
- add a new *Group Session Calendar* section on the costs page
- style the calendar table
- generate calendar in `script.js`

## Testing
- `node --version`
