### PR TITLE
Add group session dates section to session page

### DIFF
--- a/costs.html
+++ b/costs.html
@@ -55,11 +55,6 @@
       <h3>Cancellation Policy</h3>
       <p>Cancellations more than two weeks before your session are fully refundable. After that we retain a 30% deposit to cover preparation costs.</p>
     </section>
-
-      <section class="costs-section">
-        <h3>Upcoming Group Sessions</h3>
-        <p>July 6 and July 20, 2024</p>
-      </section>
     <p class="costs-location-link">For details on where sessions are held, visit our <a href="location.html">location page</a>.</p>
 
     <footer class="page-footer">

--- a/session.html
+++ b/session.html
@@ -56,6 +56,11 @@
       </div>
     </section>
 
+    <section class="costs-section">
+      <h3>Upcoming Group Sessions</h3>
+      <p>July 6 and July 20, 2024</p>
+    </section>
+
     <footer class="page-footer">
       <a href="experiences.html" class="cta-button">Show Experiences</a>
     </footer>


### PR DESCRIPTION
## Summary
- show upcoming group sessions on session page
- remove group session dates from costs page

## Testing
- `npm test` *(fails: cannot find package.json)*
- `pytest`